### PR TITLE
Add an enum for websocket events

### DIFF
--- a/crates/server/src/models/log.rs
+++ b/crates/server/src/models/log.rs
@@ -27,7 +27,7 @@ pub struct Log {
     pub duration: u32,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LogForCreate {
     pub service_id: u32,
     pub status: Status,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities for HTTP requests and responses, including optional header inclusion and adjustable logging levels.
	- Introduced a new `Event` enum for structured WebSocket event logging, enabling JSON-formatted message transmission.
  
- **Improvements**
	- Updated the ping operation logging severity for better interpretation of errors.
	- Renamed variables to clarify their purpose, improving the readability of the code.
	- Expanded the `LogForCreate` struct by adding the `Clone` trait for increased usability.

- **Bug Fixes**
	- Adjusted message sending logic in WebSocket handling to ensure messages are serialized correctly before transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->