### PR TITLE
refactor(server): Use one state for all api routes

### DIFF
--- a/crates/server/src/middlewares/log.rs
+++ b/crates/server/src/middlewares/log.rs
@@ -5,15 +5,15 @@ use tracing::debug;
 
 /// Middleware to log the response status and duration
 pub async fn request_logger(req: Request<Body>, next: Next) -> Response {
-    let start_time = Instant::now();
-
-    let method = req.method().clone();
     let uri = req.uri().clone();
 
     // Ignore static js/css assets
     if uri.path().starts_with("/_app") {
         return next.run(req).await;
     }
+
+    let start_time = Instant::now();
+    let method = req.method().clone();
 
     // Proceed to the next middleware or handler
     let response = next.run(req).await;

--- a/crates/server/src/models/log.rs
+++ b/crates/server/src/models/log.rs
@@ -245,8 +245,6 @@ mod tests {
 
         dbg!(&incidents);
 
-        //assert!(incidents.first().unwrap().id > incidents.last().unwrap().id);
-
         assert_eq!(incidents.len(), 1);
 
         Ok(())

--- a/crates/server/src/models/service.rs
+++ b/crates/server/src/models/service.rs
@@ -29,7 +29,7 @@ pub struct Service {
     pub retry: u32,
     pub retry_interval: u32,
     pub invert: bool,
-    pub expected_code: Option<u32>,
+    pub expected_code: Option<u16>,
     pub expected_payload: Option<String>,
 }
 
@@ -63,7 +63,7 @@ pub struct ServiceForUpdate {
     pub retry: Option<u16>,
     pub retry_interval: Option<u16>,
     pub invert: Option<bool>,
-    pub expected_code: Option<u32>,
+    pub expected_code: Option<u16>,
     pub expected_payload: Option<String>,
 }
 

--- a/crates/server/src/routes/auth.rs
+++ b/crates/server/src/routes/auth.rs
@@ -169,11 +169,10 @@ async fn check(State(state): State<AppState>) -> Response {
     Json(json!({"message": "Already setup"})).into_response()
 }
 
-pub fn routes(state: AppState) -> Router {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/check", get(check))
         .route("/logout", get(logout))
         .route("/login", post(login))
         .route("/register", post(register))
-        .with_state(state)
 }

--- a/crates/server/src/routes/logs.rs
+++ b/crates/server/src/routes/logs.rs
@@ -64,9 +64,8 @@ async fn list_log_incidents(
     }
 }
 
-pub fn routes(state: AppState) -> Router {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/logs", get(list_logs))
         .route("/logs/incidents", get(list_log_incidents))
-        .with_state(state)
 }

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,6 +1,6 @@
 use axum::{Json, Router, extract::State, http::StatusCode, routing::get};
 use serde_json::{Value, json};
-use tracing::{debug, error};
+use tracing::error;
 
 use crate::{
     AppState,
@@ -22,23 +22,20 @@ async fn stats(State(state): State<AppState>) -> (StatusCode, Json<Value>) {
     }
 }
 
-pub fn routes(state: AppState) -> Router<()> {
-    let stats_route = Router::new()
-        .route("/stats", get(stats))
-        .with_state(state.clone());
+pub fn routes() -> Router<AppState> {
+    let stats_route = Router::new().route("/stats", get(stats));
 
     Router::new()
-        .merge(auth::routes(state.clone()))
-        .merge(service::routes(state.clone()))
-        .merge(logs::routes(state.clone()))
-        .merge(users::routes(state.clone()))
+        .merge(auth::routes())
+        .merge(service::routes())
+        .merge(logs::routes())
+        .merge(users::routes())
         .merge(stats_route)
         .fallback(root)
 }
 
 // fallback handler that responds with a 404
 async fn root() -> (StatusCode, Json<Value>) {
-    debug!("Not found");
     (
         StatusCode::NOT_FOUND,
         Json(json!({ "message": "Not Found" })),

--- a/crates/server/src/routes/service.rs
+++ b/crates/server/src/routes/service.rs
@@ -144,10 +144,9 @@ async fn list_service_logs(
     }
 }
 
-pub fn routes(state: AppState) -> Router {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/services", get(list_services).post(add_service))
-        .route("/services/:id", put(update_service).get(get_service))
-        .route("/services/:id/logs", get(list_service_logs))
-        .with_state(state)
+        .route("/services/{id}", put(update_service).get(get_service))
+        .route("/services/{id}/logs", get(list_service_logs))
 }

--- a/crates/server/src/routes/users.rs
+++ b/crates/server/src/routes/users.rs
@@ -50,9 +50,8 @@ async fn list_users(_: Claims, State(state): State<AppState>) -> Response {
     }
 }
 
-pub fn routes(state: AppState) -> Router {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/users", get(list_users))
         .route("/user", get(get_user))
-        .with_state(state)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified route definitions by removing explicit state passing; routes now use generic state typing.
  - Updated route path parameter syntax for consistency.
  - Adjusted middleware application and route nesting for improved organization.
  - Refined request logging to better exclude static asset requests.
  - Updated expected HTTP status code field to use a more appropriate data type.

- **Tests**
  - Cleaned up test code by removing an unused assertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->