### PR TITLE
fix(auth): avoid panic on invalid password hash

### DIFF
--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -93,7 +93,10 @@ pub fn hash(val: String) -> String {
 pub fn verify_password(password: &str, hash: &str) -> bool {
     use argon2::{PasswordHash, PasswordVerifier};
 
-    let parsed_hash = PasswordHash::new(hash).expect("Invalid hash format");
+    let Ok(parsed_hash) = PasswordHash::new(hash) else {
+        return false;
+    };
+
     Argon2::default()
         .verify_password(password.as_bytes(), &parsed_hash)
         .is_ok()
@@ -168,6 +171,12 @@ mod tests {
 
         // Empty password should fail verification
         assert!(!verify_password(empty_password, &hashed));
+    }
+
+    #[test]
+    fn test_verify_password_invalid_hash() {
+        // Invalid hash input should not panic and should return false.
+        assert!(!verify_password("test_password", "not-a-valid-hash"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent server panics when a malformed or corrupted password hash is encountered by making hash-parse failures non-fatal during verification.

### Description
- Change `verify_password` to return `false` on `PasswordHash::new(...)` parse failure instead of calling `expect(...)`, and add a unit test `test_verify_password_invalid_hash` to guard the behavior.

### Testing
- Ran server auth tests with `cargo test -p server auth::tests::test_verify_password` and the server tests passed; workspace-level `cargo test` showed unrelated failures in `crates/ssl-exp` caused by a `Network is unreachable` condition.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b4b5d3d44832bbd66f023af9c7ad7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication robustness: password verification now safely handles malformed hash data instead of crashing; invalid input is gracefully rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->